### PR TITLE
size: account for omitempty

### DIFF
--- a/plugin/size/size.go
+++ b/plugin/size/size.go
@@ -234,11 +234,16 @@ func (p *size) generateField(proto3 bool, file *generator.FileDescriptor, messag
 	nullable := gogoproto.IsNullable(field)
 	repeated := field.IsRepeated()
 	doNilCheck := gogoproto.NeedsNilCheck(proto3, field)
+	omitEmpty := gogoproto.IsOmitEmpty(field)
 	if repeated {
 		p.P(`if len(m.`, fieldname, `) > 0 {`)
 		p.In()
 	} else if doNilCheck {
 		p.P(`if m.`, fieldname, ` != nil {`)
+		p.In()
+	} else if omitEmpty {
+		p.P(`// Field has gogoproto.omitempty set.`)
+		p.P(`if !m.`, fieldname, `.Empty() {`)
 		p.In()
 	}
 	packed := field.IsPacked() || (proto3 && field.IsPacked3())
@@ -570,7 +575,7 @@ func (p *size) generateField(proto3 bool, file *generator.FileDescriptor, messag
 	default:
 		panic("not implemented")
 	}
-	if repeated || doNilCheck {
+	if repeated || doNilCheck || omitEmpty {
 		p.Out()
 		p.P(`}`)
 	}

--- a/test/omitempty/combos/both/omitempty.pb.go
+++ b/test/omitempty/combos/both/omitempty.pb.go
@@ -858,8 +858,11 @@ func (m *OmitEmpty) Size() (n int) {
 	}
 	l = m.InnerNotNullable.Size()
 	n += 1 + l + sovOmitempty(uint64(l))
-	l = m.InnerOmitEmpty.Size()
-	n += 1 + l + sovOmitempty(uint64(l))
+	// Field has gogoproto.omitempty set.
+	if !m.InnerOmitEmpty.Empty() {
+		l = m.InnerOmitEmpty.Size()
+		n += 1 + l + sovOmitempty(uint64(l))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}

--- a/test/omitempty/combos/marshaler/omitempty.pb.go
+++ b/test/omitempty/combos/marshaler/omitempty.pb.go
@@ -857,8 +857,11 @@ func (m *OmitEmpty) Size() (n int) {
 	}
 	l = m.InnerNotNullable.Size()
 	n += 1 + l + sovOmitempty(uint64(l))
-	l = m.InnerOmitEmpty.Size()
-	n += 1 + l + sovOmitempty(uint64(l))
+	// Field has gogoproto.omitempty set.
+	if !m.InnerOmitEmpty.Empty() {
+		l = m.InnerOmitEmpty.Size()
+		n += 1 + l + sovOmitempty(uint64(l))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}

--- a/test/omitempty/combos/neither/omitempty.pb.go
+++ b/test/omitempty/combos/neither/omitempty.pb.go
@@ -737,8 +737,11 @@ func (m *OmitEmpty) Size() (n int) {
 	}
 	l = m.InnerNotNullable.Size()
 	n += 1 + l + sovOmitempty(uint64(l))
-	l = m.InnerOmitEmpty.Size()
-	n += 1 + l + sovOmitempty(uint64(l))
+	// Field has gogoproto.omitempty set.
+	if !m.InnerOmitEmpty.Empty() {
+		l = m.InnerOmitEmpty.Size()
+		n += 1 + l + sovOmitempty(uint64(l))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}

--- a/test/omitempty/combos/unmarshaler/omitempty.pb.go
+++ b/test/omitempty/combos/unmarshaler/omitempty.pb.go
@@ -740,8 +740,11 @@ func (m *OmitEmpty) Size() (n int) {
 	}
 	l = m.InnerNotNullable.Size()
 	n += 1 + l + sovOmitempty(uint64(l))
-	l = m.InnerOmitEmpty.Size()
-	n += 1 + l + sovOmitempty(uint64(l))
+	// Field has gogoproto.omitempty set.
+	if !m.InnerOmitEmpty.Empty() {
+		l = m.InnerOmitEmpty.Size()
+		n += 1 + l + sovOmitempty(uint64(l))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}


### PR DESCRIPTION
Follow-up to #2: account for the omitempty option when generating the code for `Size()`.