### PR TITLE
size: improve sov function

### DIFF
--- a/plugin/size/size.go
+++ b/plugin/size/size.go
@@ -186,9 +186,10 @@ func keySize(fieldNumber int32, wireType int) int {
 }
 
 func (p *size) sizeVarint() {
+	// Note: (x*37)>>8 is equivalent to x/7 for x in the [0, 64] range.
 	p.P(`
 	func sov`, p.localName, `(x uint64) (n int) {
-                return (`, p.bitsPkg.Use(), `.Len64(x | 1) + 6)/ 7
+                return int((uint32(`, p.bitsPkg.Use(), `.Len64(x | 1) + 6) * 37) >> 8)
 	}`)
 }
 

--- a/test/asymetric-issue125/asym.pb.go
+++ b/test/asymetric-issue125/asym.pb.go
@@ -398,7 +398,7 @@ func (m *M) Size() (n int) {
 }
 
 func sovAsym(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozAsym(x uint64) (n int) {
 	return sovAsym(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/cachedsize/cachedsize.pb.go
+++ b/test/cachedsize/cachedsize.pb.go
@@ -271,7 +271,7 @@ func (m *Bar) Size() (n int) {
 }
 
 func sovCachedsize(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozCachedsize(x uint64) (n int) {
 	return sovCachedsize(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/casttype/combos/both/casttype.pb.go
+++ b/test/casttype/combos/both/casttype.pb.go
@@ -1576,7 +1576,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCasttype(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozCasttype(x uint64) (n int) {
 	return sovCasttype(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/casttype/combos/marshaler/casttype.pb.go
+++ b/test/casttype/combos/marshaler/casttype.pb.go
@@ -1575,7 +1575,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCasttype(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozCasttype(x uint64) (n int) {
 	return sovCasttype(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/casttype/combos/neither/casttype.pb.go
+++ b/test/casttype/combos/neither/casttype.pb.go
@@ -1340,7 +1340,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCasttype(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozCasttype(x uint64) (n int) {
 	return sovCasttype(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/casttype/combos/unmarshaler/casttype.pb.go
+++ b/test/casttype/combos/unmarshaler/casttype.pb.go
@@ -1342,7 +1342,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCasttype(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozCasttype(x uint64) (n int) {
 	return sovCasttype(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/castvalue/castvalue.pb.go
+++ b/test/castvalue/castvalue.pb.go
@@ -844,7 +844,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCastvalue(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozCastvalue(x uint64) (n int) {
 	return sovCastvalue(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/castvalue/combos/both/castvalue.pb.go
+++ b/test/castvalue/combos/both/castvalue.pb.go
@@ -980,7 +980,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCastvalue(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozCastvalue(x uint64) (n int) {
 	return sovCastvalue(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/castvalue/combos/marshaler/castvalue.pb.go
+++ b/test/castvalue/combos/marshaler/castvalue.pb.go
@@ -979,7 +979,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCastvalue(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozCastvalue(x uint64) (n int) {
 	return sovCastvalue(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/castvalue/combos/unmarshaler/castvalue.pb.go
+++ b/test/castvalue/combos/unmarshaler/castvalue.pb.go
@@ -848,7 +848,7 @@ func (m *Wilson) Size() (n int) {
 }
 
 func sovCastvalue(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozCastvalue(x uint64) (n int) {
 	return sovCastvalue(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/combos/both/thetest.pb.go
+++ b/test/combos/both/thetest.pb.go
@@ -30954,7 +30954,7 @@ func (m *ProtoType) Size() (n int) {
 }
 
 func sovThetest(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozThetest(x uint64) (n int) {
 	return sovThetest(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/combos/marshaler/thetest.pb.go
+++ b/test/combos/marshaler/thetest.pb.go
@@ -30953,7 +30953,7 @@ func (m *ProtoType) Size() (n int) {
 }
 
 func sovThetest(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozThetest(x uint64) (n int) {
 	return sovThetest(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/combos/unmarshaler/thetest.pb.go
+++ b/test/combos/unmarshaler/thetest.pb.go
@@ -25834,7 +25834,7 @@ func (m *ProtoType) Size() (n int) {
 }
 
 func sovThetest(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozThetest(x uint64) (n int) {
 	return sovThetest(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/data/data.pb.go
+++ b/test/data/data.pb.go
@@ -313,7 +313,7 @@ func (m *MyMessage) Size() (n int) {
 }
 
 func sovData(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozData(x uint64) (n int) {
 	return sovData(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/deterministic/deterministic.pb.go
+++ b/test/deterministic/deterministic.pb.go
@@ -1373,7 +1373,7 @@ func (m *NestedMap2) Size() (n int) {
 }
 
 func sovDeterministic(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozDeterministic(x uint64) (n int) {
 	return sovDeterministic(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/enumdecl/enumdecl.pb.go
+++ b/test/enumdecl/enumdecl.pb.go
@@ -313,7 +313,7 @@ func (m *Message) Size() (n int) {
 }
 
 func sovEnumdecl(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozEnumdecl(x uint64) (n int) {
 	return sovEnumdecl(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/enumdecl_all/enumdeclall.pb.go
+++ b/test/enumdecl_all/enumdeclall.pb.go
@@ -366,7 +366,7 @@ func (m *Message) Size() (n int) {
 }
 
 func sovEnumdeclall(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozEnumdeclall(x uint64) (n int) {
 	return sovEnumdeclall(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/example/example.pb.go
+++ b/test/example/example.pb.go
@@ -1886,7 +1886,7 @@ func (m *CastType) Size() (n int) {
 }
 
 func sovExample(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozExample(x uint64) (n int) {
 	return sovExample(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/filedotname/file.dot.pb.go
+++ b/test/filedotname/file.dot.pb.go
@@ -569,7 +569,7 @@ func (m *M) Size() (n int) {
 }
 
 func sovFileDot(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozFileDot(x uint64) (n int) {
 	return sovFileDot(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/fuzztests/fuzz.pb.go
+++ b/test/fuzztests/fuzz.pb.go
@@ -1363,7 +1363,7 @@ func (m *NinOptStruct) Size() (n int) {
 }
 
 func sovFuzz(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozFuzz(x uint64) (n int) {
 	return sovFuzz(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/importcustom-issue389/imported/a.pb.go
+++ b/test/importcustom-issue389/imported/a.pb.go
@@ -259,7 +259,7 @@ func (m *A) Size() (n int) {
 }
 
 func sovA(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozA(x uint64) (n int) {
 	return sovA(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/importcustom-issue389/importing/c.pb.go
+++ b/test/importcustom-issue389/importing/c.pb.go
@@ -269,7 +269,7 @@ func (m *C) Size() (n int) {
 }
 
 func sovC(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozC(x uint64) (n int) {
 	return sovC(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/indeximport-issue72/index/index.pb.go
+++ b/test/indeximport-issue72/index/index.pb.go
@@ -301,7 +301,7 @@ func (m *IndexQuery) Size() (n int) {
 }
 
 func sovIndex(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIndex(x uint64) (n int) {
 	return sovIndex(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/indeximport-issue72/indeximport.pb.go
+++ b/test/indeximport-issue72/indeximport.pb.go
@@ -283,7 +283,7 @@ func (m *IndexQueries) Size() (n int) {
 }
 
 func sovIndeximport(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIndeximport(x uint64) (n int) {
 	return sovIndeximport(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/int64support/object.pb.go
+++ b/test/int64support/object.pb.go
@@ -316,7 +316,7 @@ func (m *Object) Size() (n int) {
 }
 
 func sovObject(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozObject(x uint64) (n int) {
 	return sovObject(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue260/issue260.pb.go
+++ b/test/issue260/issue260.pb.go
@@ -664,7 +664,7 @@ func (m *Kept) Size() (n int) {
 }
 
 func sovIssue260(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue260(x uint64) (n int) {
 	return sovIssue260(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue261/issue261.pb.go
+++ b/test/issue261/issue261.pb.go
@@ -240,7 +240,7 @@ func (m *MapStdTypes) Size() (n int) {
 }
 
 func sovIssue261(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue261(x uint64) (n int) {
 	return sovIssue261(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue262/timefail.pb.go
+++ b/test/issue262/timefail.pb.go
@@ -200,7 +200,7 @@ func (m *TimeFail) Size() (n int) {
 }
 
 func sovTimefail(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTimefail(x uint64) (n int) {
 	return sovTimefail(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue322/issue322.pb.go
+++ b/test/issue322/issue322.pb.go
@@ -487,7 +487,7 @@ func (m *OneofTest_I) Size() (n int) {
 }
 
 func sovIssue322(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue322(x uint64) (n int) {
 	return sovIssue322(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue330/issue330.pb.go
+++ b/test/issue330/issue330.pb.go
@@ -258,7 +258,7 @@ func (m *Object) Size() (n int) {
 }
 
 func sovIssue330(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue330(x uint64) (n int) {
 	return sovIssue330(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue42order/issue42.pb.go
+++ b/test/issue42order/issue42.pb.go
@@ -389,7 +389,7 @@ func (m *OrderedFields) Size() (n int) {
 }
 
 func sovIssue42(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue42(x uint64) (n int) {
 	return sovIssue42(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue438/issue438.pb.go
+++ b/test/issue438/issue438.pb.go
@@ -478,7 +478,7 @@ func (m *Types) ProtoSize() (n int) {
 }
 
 func sovIssue438(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue438(x uint64) (n int) {
 	return sovIssue438(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue444/issue444.pb.go
+++ b/test/issue444/issue444.pb.go
@@ -94,7 +94,7 @@ func (m *SizeMe) Size() (n int) {
 }
 
 func sovIssue444(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue444(x uint64) (n int) {
 	return sovIssue444(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue449/issue449.pb.go
+++ b/test/issue449/issue449.pb.go
@@ -355,7 +355,7 @@ func (m *CodeGenMsg) Size() (n int) {
 }
 
 func sovIssue449(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue449(x uint64) (n int) {
 	return sovIssue449(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue498/issue498.pb.go
+++ b/test/issue498/issue498.pb.go
@@ -357,7 +357,7 @@ func (m *Message) Size() (n int) {
 }
 
 func sovIssue498(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue498(x uint64) (n int) {
 	return sovIssue498(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue503/issue503.pb.go
+++ b/test/issue503/issue503.pb.go
@@ -477,7 +477,7 @@ func (m *Foo) Size() (n int) {
 }
 
 func sovIssue503(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue503(x uint64) (n int) {
 	return sovIssue503(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue530/issue530.pb.go
+++ b/test/issue530/issue530.pb.go
@@ -1959,7 +1959,7 @@ func (m *Bar9) Size() (n int) {
 }
 
 func sovIssue530(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue530(x uint64) (n int) {
 	return sovIssue530(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue617/issue617.pb.go
+++ b/test/issue617/issue617.pb.go
@@ -294,7 +294,7 @@ func (m *Foo_Bar) ProtoSize() (n int) {
 }
 
 func sovIssue617(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue617(x uint64) (n int) {
 	return sovIssue617(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/issue620/issue620.pb.go
+++ b/test/issue620/issue620.pb.go
@@ -222,7 +222,7 @@ func (m *BarFast) Size() (n int) {
 }
 
 func sovIssue620(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozIssue620(x uint64) (n int) {
 	return sovIssue620(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapdefaults/combos/both/map.pb.go
+++ b/test/mapdefaults/combos/both/map.pb.go
@@ -1060,7 +1060,7 @@ func (m *FakeMapEntry) Size() (n int) {
 }
 
 func sovMap(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozMap(x uint64) (n int) {
 	return sovMap(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapdefaults/combos/marshaler/map.pb.go
+++ b/test/mapdefaults/combos/marshaler/map.pb.go
@@ -1059,7 +1059,7 @@ func (m *FakeMapEntry) Size() (n int) {
 }
 
 func sovMap(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozMap(x uint64) (n int) {
 	return sovMap(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapdefaults/combos/neither/map.pb.go
+++ b/test/mapdefaults/combos/neither/map.pb.go
@@ -886,7 +886,7 @@ func (m *FakeMapEntry) Size() (n int) {
 }
 
 func sovMap(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozMap(x uint64) (n int) {
 	return sovMap(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapdefaults/combos/unmarshaler/map.pb.go
+++ b/test/mapdefaults/combos/unmarshaler/map.pb.go
@@ -887,7 +887,7 @@ func (m *FakeMapEntry) Size() (n int) {
 }
 
 func sovMap(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozMap(x uint64) (n int) {
 	return sovMap(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapsproto2/combos/both/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/both/mapsproto2.pb.go
@@ -4201,7 +4201,7 @@ func (m *AllMapsOrdered) Size() (n int) {
 }
 
 func sovMapsproto2(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozMapsproto2(x uint64) (n int) {
 	return sovMapsproto2(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapsproto2/combos/marshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/marshaler/mapsproto2.pb.go
@@ -4200,7 +4200,7 @@ func (m *AllMapsOrdered) Size() (n int) {
 }
 
 func sovMapsproto2(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozMapsproto2(x uint64) (n int) {
 	return sovMapsproto2(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapsproto2/combos/neither/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/neither/mapsproto2.pb.go
@@ -3246,7 +3246,7 @@ func (m *AllMapsOrdered) Size() (n int) {
 }
 
 func sovMapsproto2(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozMapsproto2(x uint64) (n int) {
 	return sovMapsproto2(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/mapsproto2/combos/unmarshaler/mapsproto2.pb.go
+++ b/test/mapsproto2/combos/unmarshaler/mapsproto2.pb.go
@@ -3249,7 +3249,7 @@ func (m *AllMapsOrdered) Size() (n int) {
 }
 
 func sovMapsproto2(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozMapsproto2(x uint64) (n int) {
 	return sovMapsproto2(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/nopackage/nopackage.pb.go
+++ b/test/nopackage/nopackage.pb.go
@@ -167,7 +167,7 @@ func (m *M) Size() (n int) {
 }
 
 func sovNopackage(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozNopackage(x uint64) (n int) {
 	return sovNopackage(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/omitempty/combos/both/omitempty.pb.go
+++ b/test/omitempty/combos/both/omitempty.pb.go
@@ -883,7 +883,7 @@ func (m *OmitEmpty_Inner) Size() (n int) {
 }
 
 func sovOmitempty(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOmitempty(x uint64) (n int) {
 	return sovOmitempty(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/omitempty/combos/marshaler/omitempty.pb.go
+++ b/test/omitempty/combos/marshaler/omitempty.pb.go
@@ -882,7 +882,7 @@ func (m *OmitEmpty_Inner) Size() (n int) {
 }
 
 func sovOmitempty(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOmitempty(x uint64) (n int) {
 	return sovOmitempty(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/omitempty/combos/neither/omitempty.pb.go
+++ b/test/omitempty/combos/neither/omitempty.pb.go
@@ -761,7 +761,7 @@ func (m *OmitEmpty_Inner) Size() (n int) {
 }
 
 func sovOmitempty(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOmitempty(x uint64) (n int) {
 	return sovOmitempty(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/omitempty/combos/unmarshaler/omitempty.pb.go
+++ b/test/omitempty/combos/unmarshaler/omitempty.pb.go
@@ -764,7 +764,7 @@ func (m *OmitEmpty_Inner) Size() (n int) {
 }
 
 func sovOmitempty(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOmitempty(x uint64) (n int) {
 	return sovOmitempty(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof/combos/both/one.pb.go
+++ b/test/oneof/combos/both/one.pb.go
@@ -5349,7 +5349,7 @@ func (m *CustomOneof_MyCustomName) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof/combos/marshaler/one.pb.go
+++ b/test/oneof/combos/marshaler/one.pb.go
@@ -5348,7 +5348,7 @@ func (m *CustomOneof_MyCustomName) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof/combos/neither/one.pb.go
+++ b/test/oneof/combos/neither/one.pb.go
@@ -4765,7 +4765,7 @@ func (m *CustomOneof_MyCustomName) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof/combos/unmarshaler/one.pb.go
+++ b/test/oneof/combos/unmarshaler/one.pb.go
@@ -4767,7 +4767,7 @@ func (m *CustomOneof_MyCustomName) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof3/combos/both/one.pb.go
+++ b/test/oneof3/combos/both/one.pb.go
@@ -3221,7 +3221,7 @@ func (m *SampleOneOf_SubMessage) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof3/combos/marshaler/one.pb.go
+++ b/test/oneof3/combos/marshaler/one.pb.go
@@ -3220,7 +3220,7 @@ func (m *SampleOneOf_SubMessage) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof3/combos/neither/one.pb.go
+++ b/test/oneof3/combos/neither/one.pb.go
@@ -2899,7 +2899,7 @@ func (m *SampleOneOf_SubMessage) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/oneof3/combos/unmarshaler/one.pb.go
+++ b/test/oneof3/combos/unmarshaler/one.pb.go
@@ -2901,7 +2901,7 @@ func (m *SampleOneOf_SubMessage) Size() (n int) {
 }
 
 func sovOne(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozOne(x uint64) (n int) {
 	return sovOne(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/protobuffer/protobuffer.pb.go
+++ b/test/protobuffer/protobuffer.pb.go
@@ -213,7 +213,7 @@ func (m *PBuffMarshaler) Size() (n int) {
 }
 
 func sovProtobuffer(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozProtobuffer(x uint64) (n int) {
 	return sovProtobuffer(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/protosize/protosize.pb.go
+++ b/test/protosize/protosize.pb.go
@@ -370,7 +370,7 @@ func (m *SizeMessage) ProtoSize() (n int) {
 }
 
 func sovProtosize(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozProtosize(x uint64) (n int) {
 	return sovProtosize(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/required/requiredexample.pb.go
+++ b/test/required/requiredexample.pb.go
@@ -1195,7 +1195,7 @@ func (m *NestedNinOptNative) Size() (n int) {
 }
 
 func sovRequiredexample(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozRequiredexample(x uint64) (n int) {
 	return sovRequiredexample(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/sizeunderscore/sizeunderscore.pb.go
+++ b/test/sizeunderscore/sizeunderscore.pb.go
@@ -337,7 +337,7 @@ func (m *SizeMessage) Size() (n int) {
 }
 
 func sovSizeunderscore(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozSizeunderscore(x uint64) (n int) {
 	return sovSizeunderscore(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/stdtypes/stdtypes.pb.go
+++ b/test/stdtypes/stdtypes.pb.go
@@ -4612,7 +4612,7 @@ func (m *OneofStdTypes_RepBytes) Size() (n int) {
 }
 
 func sovStdtypes(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozStdtypes(x uint64) (n int) {
 	return sovStdtypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/theproto3/combos/both/theproto3.pb.go
+++ b/test/theproto3/combos/both/theproto3.pb.go
@@ -6053,7 +6053,7 @@ func (m *NotPacked) Size() (n int) {
 }
 
 func sovTheproto3(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTheproto3(x uint64) (n int) {
 	return sovTheproto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/theproto3/combos/marshaler/theproto3.pb.go
+++ b/test/theproto3/combos/marshaler/theproto3.pb.go
@@ -6053,7 +6053,7 @@ func (m *NotPacked) Size() (n int) {
 }
 
 func sovTheproto3(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTheproto3(x uint64) (n int) {
 	return sovTheproto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/theproto3/combos/neither/theproto3.pb.go
+++ b/test/theproto3/combos/neither/theproto3.pb.go
@@ -4728,7 +4728,7 @@ func (m *NotPacked) Size() (n int) {
 }
 
 func sovTheproto3(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTheproto3(x uint64) (n int) {
 	return sovTheproto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/theproto3/combos/unmarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unmarshaler/theproto3.pb.go
@@ -4731,7 +4731,7 @@ func (m *NotPacked) Size() (n int) {
 }
 
 func sovTheproto3(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTheproto3(x uint64) (n int) {
 	return sovTheproto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/thetest.pb.go
+++ b/test/thetest.pb.go
@@ -25831,7 +25831,7 @@ func (m *ProtoType) Size() (n int) {
 }
 
 func sovThetest(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozThetest(x uint64) (n int) {
 	return sovThetest(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/typedecl/typedecl.pb.go
+++ b/test/typedecl/typedecl.pb.go
@@ -638,7 +638,7 @@ func (m *Kept) Size() (n int) {
 }
 
 func sovTypedecl(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTypedecl(x uint64) (n int) {
 	return sovTypedecl(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/typedecl_all/typedeclall.pb.go
+++ b/test/typedecl_all/typedeclall.pb.go
@@ -638,7 +638,7 @@ func (m *Kept) Size() (n int) {
 }
 
 func sovTypedeclall(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTypedeclall(x uint64) (n int) {
 	return sovTypedeclall(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/types/combos/both/types.pb.go
+++ b/test/types/combos/both/types.pb.go
@@ -11647,7 +11647,7 @@ func (m *OneofStdTypes_RepBytes) Size() (n int) {
 }
 
 func sovTypes(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/types/combos/marshaler/types.pb.go
+++ b/test/types/combos/marshaler/types.pb.go
@@ -11646,7 +11646,7 @@ func (m *OneofStdTypes_RepBytes) Size() (n int) {
 }
 
 func sovTypes(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/types/combos/neither/types.pb.go
+++ b/test/types/combos/neither/types.pb.go
@@ -8643,7 +8643,7 @@ func (m *OneofStdTypes_RepBytes) Size() (n int) {
 }
 
 func sovTypes(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/types/combos/unmarshaler/types.pb.go
+++ b/test/types/combos/unmarshaler/types.pb.go
@@ -8644,7 +8644,7 @@ func (m *OneofStdTypes_RepBytes) Size() (n int) {
 }
 
 func sovTypes(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTypes(x uint64) (n int) {
 	return sovTypes(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/unrecognized/unrecognized.pb.go
+++ b/test/unrecognized/unrecognized.pb.go
@@ -3027,7 +3027,7 @@ func (m *OldU) Size() (n int) {
 }
 
 func sovUnrecognized(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozUnrecognized(x uint64) (n int) {
 	return sovUnrecognized(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/test/unrecognizedgroup/unrecognizedgroup.pb.go
+++ b/test/unrecognizedgroup/unrecognizedgroup.pb.go
@@ -1431,7 +1431,7 @@ func (m *A) Size() (n int) {
 }
 
 func sovUnrecognizedgroup(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozUnrecognizedgroup(x uint64) (n int) {
 	return sovUnrecognizedgroup(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/any.pb.go
+++ b/types/any.pb.go
@@ -463,7 +463,7 @@ func (m *Any) Size() (n int) {
 }
 
 func sovAny(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozAny(x uint64) (n int) {
 	return sovAny(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/api.pb.go
+++ b/types/api.pb.go
@@ -1342,7 +1342,7 @@ func (m *Mixin) Size() (n int) {
 }
 
 func sovApi(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozApi(x uint64) (n int) {
 	return sovApi(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/duration.pb.go
+++ b/types/duration.pb.go
@@ -335,7 +335,7 @@ func (m *Duration) Size() (n int) {
 }
 
 func sovDuration(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozDuration(x uint64) (n int) {
 	return sovDuration(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/empty.pb.go
+++ b/types/empty.pb.go
@@ -302,7 +302,7 @@ func (m *Empty) Size() (n int) {
 }
 
 func sovEmpty(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozEmpty(x uint64) (n int) {
 	return sovEmpty(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/field_mask.pb.go
+++ b/types/field_mask.pb.go
@@ -544,7 +544,7 @@ func (m *FieldMask) Size() (n int) {
 }
 
 func sovFieldMask(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozFieldMask(x uint64) (n int) {
 	return sovFieldMask(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/source_context.pb.go
+++ b/types/source_context.pb.go
@@ -331,7 +331,7 @@ func (m *SourceContext) Size() (n int) {
 }
 
 func sovSourceContext(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozSourceContext(x uint64) (n int) {
 	return sovSourceContext(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/struct.pb.go
+++ b/types/struct.pb.go
@@ -1594,7 +1594,7 @@ func (m *ListValue) Size() (n int) {
 }
 
 func sovStruct(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozStruct(x uint64) (n int) {
 	return sovStruct(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/timestamp.pb.go
+++ b/types/timestamp.pb.go
@@ -356,7 +356,7 @@ func (m *Timestamp) Size() (n int) {
 }
 
 func sovTimestamp(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozTimestamp(x uint64) (n int) {
 	return sovTimestamp(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/type.pb.go
+++ b/types/type.pb.go
@@ -2142,7 +2142,7 @@ func (m *Option) Size() (n int) {
 }
 
 func sovType(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozType(x uint64) (n int) {
 	return sovType(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/types/wrappers.pb.go
+++ b/types/wrappers.pb.go
@@ -1862,7 +1862,7 @@ func (m *BytesValue) Size() (n int) {
 }
 
 func sovWrappers(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozWrappers(x uint64) (n int) {
 	return sovWrappers(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/fast/gogovanity.pb.go
+++ b/vanity/test/fast/gogovanity.pb.go
@@ -186,7 +186,7 @@ func (m *B) Size() (n int) {
 }
 
 func sovGogovanity(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozGogovanity(x uint64) (n int) {
 	return sovGogovanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/fast/proto3.pb.go
+++ b/vanity/test/fast/proto3.pb.go
@@ -147,7 +147,7 @@ func (m *Aproto3) Size() (n int) {
 }
 
 func sovProto3(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozProto3(x uint64) (n int) {
 	return sovProto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/fast/vanity.pb.go
+++ b/vanity/test/fast/vanity.pb.go
@@ -167,7 +167,7 @@ func (m *A) Size() (n int) {
 }
 
 func sovVanity(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozVanity(x uint64) (n int) {
 	return sovVanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/faster/gogovanity.pb.go
+++ b/vanity/test/faster/gogovanity.pb.go
@@ -173,7 +173,7 @@ func (m *B) Size() (n int) {
 }
 
 func sovGogovanity(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozGogovanity(x uint64) (n int) {
 	return sovGogovanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/faster/proto3.pb.go
+++ b/vanity/test/faster/proto3.pb.go
@@ -137,7 +137,7 @@ func (m *Aproto3) Size() (n int) {
 }
 
 func sovProto3(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozProto3(x uint64) (n int) {
 	return sovProto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/faster/vanity.pb.go
+++ b/vanity/test/faster/vanity.pb.go
@@ -148,7 +148,7 @@ func (m *A) Size() (n int) {
 }
 
 func sovVanity(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozVanity(x uint64) (n int) {
 	return sovVanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/slick/gogovanity.pb.go
+++ b/vanity/test/slick/gogovanity.pb.go
@@ -242,7 +242,7 @@ func (m *B) Size() (n int) {
 }
 
 func sovGogovanity(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozGogovanity(x uint64) (n int) {
 	return sovGogovanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/slick/proto3.pb.go
+++ b/vanity/test/slick/proto3.pb.go
@@ -182,7 +182,7 @@ func (m *Aproto3) Size() (n int) {
 }
 
 func sovProto3(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozProto3(x uint64) (n int) {
 	return sovProto3(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/vanity/test/slick/vanity.pb.go
+++ b/vanity/test/slick/vanity.pb.go
@@ -197,7 +197,7 @@ func (m *A) Size() (n int) {
 }
 
 func sovVanity(x uint64) (n int) {
-	return (math_bits.Len64(x|1) + 6) / 7
+	return int((uint32(math_bits.Len64(x|1)+6) * 37) >> 8)
 }
 func sozVanity(x uint64) (n int) {
 	return sovVanity(uint64((x << 1) ^ uint64((int64(x) >> 63))))


### PR DESCRIPTION
Speed up the function to determine how many bytes of varint encoding are necessary; implementation taken from
https://github.com/cockroachdb/crlib/blob/main/crencoding/var_int.go#L32