### PR TITLE
unmarshal: reuse packed slices when possible

### DIFF
--- a/test/casttype/combos/both/casttype.pb.go
+++ b/test/casttype/combos/both/casttype.pb.go
@@ -19,6 +19,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	strings "strings"
 )
 
@@ -1939,8 +1940,12 @@ func (m *Castaway) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.MyUint64S) == 0 {
-					m.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, 0, elementCount)
+				if elementCount != 0 {
+					if m.MyUint64S == nil {
+						m.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, 0, elementCount)
+					} else {
+						m.MyUint64S = slices.Grow(m.MyUint64S, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v github_com_gogo_protobuf_test_casttype.MyUint64Type

--- a/test/casttype/combos/unmarshaler/casttype.pb.go
+++ b/test/casttype/combos/unmarshaler/casttype.pb.go
@@ -19,6 +19,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	strings "strings"
 )
 
@@ -1705,8 +1706,12 @@ func (m *Castaway) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.MyUint64S) == 0 {
-					m.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, 0, elementCount)
+				if elementCount != 0 {
+					if m.MyUint64S == nil {
+						m.MyUint64S = make([]github_com_gogo_protobuf_test_casttype.MyUint64Type, 0, elementCount)
+					} else {
+						m.MyUint64S = slices.Grow(m.MyUint64S, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v github_com_gogo_protobuf_test_casttype.MyUint64Type

--- a/test/combos/both/thetest.pb.go
+++ b/test/combos/both/thetest.pb.go
@@ -20,6 +20,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	sort "sort"
 	strconv "strconv"
 	strings "strings"
@@ -32990,8 +32991,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -33044,8 +33049,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -33112,8 +33121,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -33188,8 +33201,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -33264,8 +33281,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -33340,8 +33361,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -33417,8 +33442,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -33495,8 +33524,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -33557,8 +33590,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -33609,8 +33646,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -33661,8 +33702,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -33713,8 +33758,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -33774,8 +33823,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -33951,8 +34004,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -34005,8 +34062,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -34073,8 +34134,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -34149,8 +34214,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -34225,8 +34294,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -34301,8 +34374,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -34378,8 +34455,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -34456,8 +34537,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -34518,8 +34603,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -34570,8 +34659,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -34622,8 +34715,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -34674,8 +34771,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -34735,8 +34836,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -34912,8 +35017,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -34966,8 +35075,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -35034,8 +35147,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -35110,8 +35227,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -35186,8 +35307,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -35262,8 +35387,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -35339,8 +35468,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -35417,8 +35550,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -35479,8 +35616,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -35531,8 +35672,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -35583,8 +35728,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -35635,8 +35784,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -35696,8 +35849,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -35809,8 +35966,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -35863,8 +36024,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -35931,8 +36096,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -36007,8 +36176,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -36083,8 +36256,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -36159,8 +36336,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -36236,8 +36417,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -36314,8 +36499,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -36376,8 +36565,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -36428,8 +36621,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -36480,8 +36677,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -36532,8 +36733,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -36593,8 +36798,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -37316,8 +37525,12 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -37370,8 +37583,12 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -37506,8 +37723,12 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -37583,8 +37804,12 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -37688,8 +37913,12 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -37865,8 +38094,12 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -37919,8 +38152,12 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -38055,8 +38292,12 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -38132,8 +38373,12 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -38237,8 +38482,12 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -41503,8 +41752,12 @@ func (m *NidRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]TheTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]TheTestEnum, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v TheTestEnum
@@ -41572,8 +41825,12 @@ func (m *NidRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]YetAnotherTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]YetAnotherTestEnum, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v YetAnotherTestEnum
@@ -41641,8 +41898,12 @@ func (m *NidRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]YetYetAnotherTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]YetYetAnotherTestEnum, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v YetYetAnotherTestEnum
@@ -41761,8 +42022,12 @@ func (m *NinRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]TheTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]TheTestEnum, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v TheTestEnum
@@ -41830,8 +42095,12 @@ func (m *NinRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]YetAnotherTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]YetAnotherTestEnum, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v YetAnotherTestEnum
@@ -41899,8 +42168,12 @@ func (m *NinRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]YetYetAnotherTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]YetYetAnotherTestEnum, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v YetYetAnotherTestEnum
@@ -44245,8 +44518,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.FieldA) == 0 {
-					m.FieldA = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldA == nil {
+						m.FieldA = make([]float64, 0, elementCount)
+					} else {
+						m.FieldA = slices.Grow(m.FieldA, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -44299,8 +44576,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.FieldB) == 0 {
-					m.FieldB = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldB == nil {
+						m.FieldB = make([]float32, 0, elementCount)
+					} else {
+						m.FieldB = slices.Grow(m.FieldB, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -44367,8 +44648,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldC) == 0 {
-					m.FieldC = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldC == nil {
+						m.FieldC = make([]int32, 0, elementCount)
+					} else {
+						m.FieldC = slices.Grow(m.FieldC, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -44443,8 +44728,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldD) == 0 {
-					m.FieldD = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldD == nil {
+						m.FieldD = make([]int64, 0, elementCount)
+					} else {
+						m.FieldD = slices.Grow(m.FieldD, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -44519,8 +44808,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldE) == 0 {
-					m.FieldE = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldE == nil {
+						m.FieldE = make([]uint32, 0, elementCount)
+					} else {
+						m.FieldE = slices.Grow(m.FieldE, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -44595,8 +44888,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldF) == 0 {
-					m.FieldF = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldF == nil {
+						m.FieldF = make([]uint64, 0, elementCount)
+					} else {
+						m.FieldF = slices.Grow(m.FieldF, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -44672,8 +44969,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldG) == 0 {
-					m.FieldG = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldG == nil {
+						m.FieldG = make([]int32, 0, elementCount)
+					} else {
+						m.FieldG = slices.Grow(m.FieldG, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -44750,8 +45051,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldH) == 0 {
-					m.FieldH = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldH == nil {
+						m.FieldH = make([]int64, 0, elementCount)
+					} else {
+						m.FieldH = slices.Grow(m.FieldH, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -44812,8 +45117,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.FieldI) == 0 {
-					m.FieldI = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldI == nil {
+						m.FieldI = make([]uint32, 0, elementCount)
+					} else {
+						m.FieldI = slices.Grow(m.FieldI, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -44864,8 +45173,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.FieldJ) == 0 {
-					m.FieldJ = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldJ == nil {
+						m.FieldJ = make([]int32, 0, elementCount)
+					} else {
+						m.FieldJ = slices.Grow(m.FieldJ, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -44916,8 +45229,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.FieldK) == 0 {
-					m.FieldK = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldK == nil {
+						m.FieldK = make([]uint64, 0, elementCount)
+					} else {
+						m.FieldK = slices.Grow(m.FieldK, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -44968,8 +45285,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.FieldL) == 0 {
-					m.FieldL = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldL == nil {
+						m.FieldL = make([]int64, 0, elementCount)
+					} else {
+						m.FieldL = slices.Grow(m.FieldL, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -45029,8 +45350,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.FieldM) == 0 {
-					m.FieldM = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldM == nil {
+						m.FieldM = make([]bool, 0, elementCount)
+					} else {
+						m.FieldM = slices.Grow(m.FieldM, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -45878,8 +46203,12 @@ func (m *CustomNameEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.FieldB) == 0 {
-					m.FieldB = make([]TheTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldB == nil {
+						m.FieldB = make([]TheTestEnum, 0, elementCount)
+					} else {
+						m.FieldB = slices.Grow(m.FieldB, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v TheTestEnum

--- a/test/combos/unmarshaler/thetest.pb.go
+++ b/test/combos/unmarshaler/thetest.pb.go
@@ -20,6 +20,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	sort "sort"
 	strconv "strconv"
 	strings "strings"
@@ -27870,8 +27871,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -27924,8 +27929,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -27992,8 +28001,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -28068,8 +28081,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -28144,8 +28161,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -28220,8 +28241,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -28297,8 +28322,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -28375,8 +28404,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -28437,8 +28470,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -28489,8 +28526,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -28541,8 +28582,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -28593,8 +28638,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -28654,8 +28703,12 @@ func (m *NidRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -28831,8 +28884,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -28885,8 +28942,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -28953,8 +29014,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -29029,8 +29094,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -29105,8 +29174,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -29181,8 +29254,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -29258,8 +29335,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -29336,8 +29417,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -29398,8 +29483,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -29450,8 +29539,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -29502,8 +29595,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -29554,8 +29651,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -29615,8 +29716,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -29792,8 +29897,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -29846,8 +29955,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -29914,8 +30027,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -29990,8 +30107,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -30066,8 +30187,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -30142,8 +30267,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -30219,8 +30348,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -30297,8 +30430,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -30359,8 +30496,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -30411,8 +30552,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -30463,8 +30608,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -30515,8 +30664,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -30576,8 +30729,12 @@ func (m *NidRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -30689,8 +30846,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -30743,8 +30904,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -30811,8 +30976,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -30887,8 +31056,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -30963,8 +31136,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -31039,8 +31216,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -31116,8 +31297,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -31194,8 +31379,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -31256,8 +31445,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -31308,8 +31501,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -31360,8 +31557,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -31412,8 +31613,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -31473,8 +31678,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -32196,8 +32405,12 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -32250,8 +32463,12 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -32386,8 +32603,12 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -32463,8 +32684,12 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -32568,8 +32793,12 @@ func (m *NidRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -32745,8 +32974,12 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -32799,8 +33032,12 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -32935,8 +33172,12 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -33012,8 +33253,12 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -33117,8 +33362,12 @@ func (m *NinRepStruct) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -36383,8 +36632,12 @@ func (m *NidRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]TheTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]TheTestEnum, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v TheTestEnum
@@ -36452,8 +36705,12 @@ func (m *NidRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]YetAnotherTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]YetAnotherTestEnum, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v YetAnotherTestEnum
@@ -36521,8 +36778,12 @@ func (m *NidRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]YetYetAnotherTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]YetYetAnotherTestEnum, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v YetYetAnotherTestEnum
@@ -36641,8 +36902,12 @@ func (m *NinRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]TheTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]TheTestEnum, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v TheTestEnum
@@ -36710,8 +36975,12 @@ func (m *NinRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]YetAnotherTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]YetAnotherTestEnum, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v YetAnotherTestEnum
@@ -36779,8 +37048,12 @@ func (m *NinRepEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]YetYetAnotherTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]YetYetAnotherTestEnum, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v YetYetAnotherTestEnum
@@ -39125,8 +39398,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.FieldA) == 0 {
-					m.FieldA = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldA == nil {
+						m.FieldA = make([]float64, 0, elementCount)
+					} else {
+						m.FieldA = slices.Grow(m.FieldA, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -39179,8 +39456,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.FieldB) == 0 {
-					m.FieldB = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldB == nil {
+						m.FieldB = make([]float32, 0, elementCount)
+					} else {
+						m.FieldB = slices.Grow(m.FieldB, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -39247,8 +39528,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldC) == 0 {
-					m.FieldC = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldC == nil {
+						m.FieldC = make([]int32, 0, elementCount)
+					} else {
+						m.FieldC = slices.Grow(m.FieldC, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -39323,8 +39608,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldD) == 0 {
-					m.FieldD = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldD == nil {
+						m.FieldD = make([]int64, 0, elementCount)
+					} else {
+						m.FieldD = slices.Grow(m.FieldD, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -39399,8 +39688,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldE) == 0 {
-					m.FieldE = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldE == nil {
+						m.FieldE = make([]uint32, 0, elementCount)
+					} else {
+						m.FieldE = slices.Grow(m.FieldE, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -39475,8 +39768,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldF) == 0 {
-					m.FieldF = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldF == nil {
+						m.FieldF = make([]uint64, 0, elementCount)
+					} else {
+						m.FieldF = slices.Grow(m.FieldF, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -39552,8 +39849,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldG) == 0 {
-					m.FieldG = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldG == nil {
+						m.FieldG = make([]int32, 0, elementCount)
+					} else {
+						m.FieldG = slices.Grow(m.FieldG, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -39630,8 +39931,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.FieldH) == 0 {
-					m.FieldH = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldH == nil {
+						m.FieldH = make([]int64, 0, elementCount)
+					} else {
+						m.FieldH = slices.Grow(m.FieldH, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -39692,8 +39997,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.FieldI) == 0 {
-					m.FieldI = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldI == nil {
+						m.FieldI = make([]uint32, 0, elementCount)
+					} else {
+						m.FieldI = slices.Grow(m.FieldI, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -39744,8 +40053,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.FieldJ) == 0 {
-					m.FieldJ = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldJ == nil {
+						m.FieldJ = make([]int32, 0, elementCount)
+					} else {
+						m.FieldJ = slices.Grow(m.FieldJ, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -39796,8 +40109,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.FieldK) == 0 {
-					m.FieldK = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldK == nil {
+						m.FieldK = make([]uint64, 0, elementCount)
+					} else {
+						m.FieldK = slices.Grow(m.FieldK, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -39848,8 +40165,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.FieldL) == 0 {
-					m.FieldL = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldL == nil {
+						m.FieldL = make([]int64, 0, elementCount)
+					} else {
+						m.FieldL = slices.Grow(m.FieldL, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -39909,8 +40230,12 @@ func (m *CustomNameNinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.FieldM) == 0 {
-					m.FieldM = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldM == nil {
+						m.FieldM = make([]bool, 0, elementCount)
+					} else {
+						m.FieldM = slices.Grow(m.FieldM, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -40758,8 +41083,12 @@ func (m *CustomNameEnum) Unmarshal(dAtA []byte) error {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
-				if elementCount != 0 && len(m.FieldB) == 0 {
-					m.FieldB = make([]TheTestEnum, 0, elementCount)
+				if elementCount != 0 {
+					if m.FieldB == nil {
+						m.FieldB = make([]TheTestEnum, 0, elementCount)
+					} else {
+						m.FieldB = slices.Grow(m.FieldB, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v TheTestEnum

--- a/test/fuzztests/fuzz.pb.go
+++ b/test/fuzztests/fuzz.pb.go
@@ -12,6 +12,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	strings "strings"
 )
 
@@ -1486,8 +1487,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -1540,8 +1545,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -1608,8 +1617,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -1684,8 +1697,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -1760,8 +1777,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -1836,8 +1857,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -1913,8 +1938,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -1991,8 +2020,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -2053,8 +2086,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -2105,8 +2142,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -2157,8 +2198,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -2209,8 +2254,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -2270,8 +2319,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int

--- a/test/issue503/issue503.pb.go
+++ b/test/issue503/issue503.pb.go
@@ -11,6 +11,7 @@ import (
 	io "io"
 	math "math"
 	math_bits "math/bits"
+	slices "slices"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -563,8 +564,12 @@ func (m *Foo) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Num1) == 0 {
-					m.Num1 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Num1 == nil {
+						m.Num1 = make([]int64, 0, elementCount)
+					} else {
+						m.Num1 = slices.Grow(m.Num1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -639,8 +644,12 @@ func (m *Foo) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Num2) == 0 {
-					m.Num2 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Num2 == nil {
+						m.Num2 = make([]int32, 0, elementCount)
+					} else {
+						m.Num2 = slices.Grow(m.Num2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32

--- a/test/packed/packed.pb.go
+++ b/test/packed/packed.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
+	slices "slices"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1228,8 +1229,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -1282,8 +1287,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -1350,8 +1359,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -1426,8 +1439,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -1502,8 +1519,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -1578,8 +1599,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -1655,8 +1680,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -1733,8 +1762,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -1795,8 +1828,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -1847,8 +1884,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -1899,8 +1940,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -1951,8 +1996,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -2012,8 +2061,12 @@ func (m *NinRepNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -2125,8 +2178,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -2179,8 +2236,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -2247,8 +2308,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -2323,8 +2388,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -2399,8 +2468,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -2475,8 +2548,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -2552,8 +2629,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -2630,8 +2711,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -2692,8 +2777,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -2744,8 +2833,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -2796,8 +2889,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -2848,8 +2945,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -2909,8 +3010,12 @@ func (m *NinRepPackedNative) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -3022,8 +3127,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -3076,8 +3185,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -3144,8 +3257,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -3220,8 +3337,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -3296,8 +3417,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -3372,8 +3497,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -3449,8 +3578,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -3527,8 +3660,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -3589,8 +3726,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -3641,8 +3782,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -3693,8 +3838,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -3745,8 +3894,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -3806,8 +3959,12 @@ func (m *NinRepNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int
@@ -3919,8 +4076,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field1) == 0 {
-					m.Field1 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field1 == nil {
+						m.Field1 = make([]float64, 0, elementCount)
+					} else {
+						m.Field1 = slices.Grow(m.Field1, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -3973,8 +4134,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float32, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -4041,8 +4206,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]int32, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -4117,8 +4286,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field4) == 0 {
-					m.Field4 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field4 == nil {
+						m.Field4 = make([]int64, 0, elementCount)
+					} else {
+						m.Field4 = slices.Grow(m.Field4, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -4193,8 +4366,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field5) == 0 {
-					m.Field5 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field5 == nil {
+						m.Field5 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field5 = slices.Grow(m.Field5, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -4269,8 +4446,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field6) == 0 {
-					m.Field6 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field6 == nil {
+						m.Field6 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field6 = slices.Grow(m.Field6, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -4346,8 +4527,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]int32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -4424,8 +4609,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Field8) == 0 {
-					m.Field8 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field8 == nil {
+						m.Field8 = make([]int64, 0, elementCount)
+					} else {
+						m.Field8 = slices.Grow(m.Field8, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -4486,8 +4675,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field9) == 0 {
-					m.Field9 = make([]uint32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field9 == nil {
+						m.Field9 = make([]uint32, 0, elementCount)
+					} else {
+						m.Field9 = slices.Grow(m.Field9, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -4538,8 +4731,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field10) == 0 {
-					m.Field10 = make([]int32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field10 == nil {
+						m.Field10 = make([]int32, 0, elementCount)
+					} else {
+						m.Field10 = slices.Grow(m.Field10, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int32
@@ -4590,8 +4787,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field11) == 0 {
-					m.Field11 = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field11 == nil {
+						m.Field11 = make([]uint64, 0, elementCount)
+					} else {
+						m.Field11 = slices.Grow(m.Field11, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -4642,8 +4843,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field12) == 0 {
-					m.Field12 = make([]int64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field12 == nil {
+						m.Field12 = make([]int64, 0, elementCount)
+					} else {
+						m.Field12 = slices.Grow(m.Field12, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int64
@@ -4703,8 +4908,12 @@ func (m *NinRepPackedNativeUnsafe) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen
-				if elementCount != 0 && len(m.Field13) == 0 {
-					m.Field13 = make([]bool, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field13 == nil {
+						m.Field13 = make([]bool, 0, elementCount)
+					} else {
+						m.Field13 = slices.Grow(m.Field13, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v int

--- a/test/theproto3/combos/both/theproto3.pb.go
+++ b/test/theproto3/combos/both/theproto3.pb.go
@@ -20,6 +20,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	strconv "strconv"
 	strings "strings"
 )
@@ -6806,8 +6807,12 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Key) == 0 {
-					m.Key = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Key == nil {
+						m.Key = make([]uint64, 0, elementCount)
+					} else {
+						m.Key = slices.Grow(m.Key, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -11741,8 +11746,12 @@ func (m *NotPacked) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Key) == 0 {
-					m.Key = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Key == nil {
+						m.Key = make([]uint64, 0, elementCount)
+					} else {
+						m.Key = slices.Grow(m.Key, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64

--- a/test/theproto3/combos/unmarshaler/theproto3.pb.go
+++ b/test/theproto3/combos/unmarshaler/theproto3.pb.go
@@ -20,6 +20,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	strconv "strconv"
 	strings "strings"
 )
@@ -5534,8 +5535,12 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Key) == 0 {
-					m.Key = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Key == nil {
+						m.Key = make([]uint64, 0, elementCount)
+					} else {
+						m.Key = slices.Grow(m.Key, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -10419,8 +10424,12 @@ func (m *NotPacked) Unmarshal(dAtA []byte) error {
 					}
 				}
 				elementCount = count
-				if elementCount != 0 && len(m.Key) == 0 {
-					m.Key = make([]uint64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Key == nil {
+						m.Key = make([]uint64, 0, elementCount)
+					} else {
+						m.Key = slices.Grow(m.Key, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64

--- a/test/unrecognized/unrecognized.pb.go
+++ b/test/unrecognized/unrecognized.pb.go
@@ -17,6 +17,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	strings "strings"
 )
 
@@ -3695,8 +3696,12 @@ func (m *C) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]float32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -3800,8 +3805,12 @@ func (m *U) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float64, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64
@@ -4236,8 +4245,12 @@ func (m *OldC) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 4
-				if elementCount != 0 && len(m.Field7) == 0 {
-					m.Field7 = make([]float32, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field7 == nil {
+						m.Field7 = make([]float32, 0, elementCount)
+					} else {
+						m.Field7 = slices.Grow(m.Field7, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint32
@@ -4374,8 +4387,12 @@ func (m *OldU) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field2) == 0 {
-					m.Field2 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field2 == nil {
+						m.Field2 = make([]float64, 0, elementCount)
+					} else {
+						m.Field2 = slices.Grow(m.Field2, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64

--- a/test/unrecognizedgroup/unrecognizedgroup.pb.go
+++ b/test/unrecognizedgroup/unrecognizedgroup.pb.go
@@ -17,6 +17,7 @@ import (
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
+	slices "slices"
 	strings "strings"
 )
 
@@ -1594,8 +1595,12 @@ func (m *NewNoGroup) Unmarshal(dAtA []byte) error {
 				}
 				var elementCount int
 				elementCount = packedLen / 8
-				if elementCount != 0 && len(m.Field3) == 0 {
-					m.Field3 = make([]float64, 0, elementCount)
+				if elementCount != 0 {
+					if m.Field3 == nil {
+						m.Field3 = make([]float64, 0, elementCount)
+					} else {
+						m.Field3 = slices.Grow(m.Field3, elementCount)
+					}
 				}
 				for iNdEx < postIndex {
 					var v uint64


### PR DESCRIPTION
Note: this PR is only for the top commit.

When unmarshaling a packed slice, we reuse the slice if possible
(instead of always allocating a new one). This change is a no-op in
most cases where we use `proto.Unmarshal` which calls `Reset()` in the
message. However, it allows optimized paths to use the `Unmarshal`
method directly and avoid allocations.
