### PR TITLE
omitempty: use IsEmpty instead of Empty

### DIFF
--- a/gogoproto/gogo.proto
+++ b/gogoproto/gogo.proto
@@ -143,8 +143,8 @@ extend google.protobuf.FieldOptions {
 
 
 	// omitempty is used to skip marshaling non-nullable fields which are empty
-	// (unset). The field's type must implement an `.Empty()` method which will be
-	// consulted prior to marshaling.
+	// (unset). The field's type must implement an `IsEmpty() bool` method which
+	// will be consulted prior to marshaling.
 	//
 	// Added by cockroach.
 	optional bool omitempty = 65013;

--- a/plugin/marshalto/marshalto.go
+++ b/plugin/marshalto/marshalto.go
@@ -357,7 +357,7 @@ func (p *marshalto) generateField(proto3 bool, numGen NumGen, file *generator.Fi
 		p.In()
 	} else if omitEmpty {
 		p.P(`// Field has gogoproto.omitempty set.`)
-		p.P(`if !m.`, fieldname, `.Empty() {`)
+		p.P(`if !m.`, fieldname, `.IsEmpty() {`)
 		p.In()
 	}
 	packed := field.IsPacked() || (proto3 && field.IsPacked3())
@@ -706,7 +706,7 @@ func (p *marshalto) generateField(proto3 bool, numGen NumGen, file *generator.Fi
 				p.In()
 			} else if omitEmpty {
 				p.P(`// Field has gogoproto.omitempty set.`)
-				p.P(`if !`, accessor, `.Empty() {`)
+				p.P(`if !`, accessor, `.IsEmpty() {`)
 				p.In()
 			}
 			p.mapField(numGen, field, m.ValueAliasField, accessor, protoSizer)

--- a/plugin/size/size.go
+++ b/plugin/size/size.go
@@ -244,7 +244,7 @@ func (p *size) generateField(proto3 bool, file *generator.FileDescriptor, messag
 		p.In()
 	} else if omitEmpty {
 		p.P(`// Field has gogoproto.omitempty set.`)
-		p.P(`if !m.`, fieldname, `.Empty() {`)
+		p.P(`if !m.`, fieldname, `.IsEmpty() {`)
 		p.In()
 	}
 	packed := field.IsPacked() || (proto3 && field.IsPacked3())

--- a/test/omitempty/combos/both/mymethod.go
+++ b/test/omitempty/combos/both/mymethod.go
@@ -1,5 +1,5 @@
 package omitempty
 
-func (o *OmitEmpty_Inner) Empty() bool {
+func (o *OmitEmpty_Inner) IsEmpty() bool {
 	return o.Foo == 0
 }

--- a/test/omitempty/combos/both/omitempty.pb.go
+++ b/test/omitempty/combos/both/omitempty.pb.go
@@ -669,7 +669,7 @@ func (m *OmitEmpty) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	// Field has gogoproto.omitempty set.
-	if !m.InnerOmitEmpty.Empty() {
+	if !m.InnerOmitEmpty.IsEmpty() {
 		{
 			size, err := m.InnerOmitEmpty.MarshalToSizedBuffer(dAtA[:i])
 			if err != nil {
@@ -859,7 +859,7 @@ func (m *OmitEmpty) Size() (n int) {
 	l = m.InnerNotNullable.Size()
 	n += 1 + l + sovOmitempty(uint64(l))
 	// Field has gogoproto.omitempty set.
-	if !m.InnerOmitEmpty.Empty() {
+	if !m.InnerOmitEmpty.IsEmpty() {
 		l = m.InnerOmitEmpty.Size()
 		n += 1 + l + sovOmitempty(uint64(l))
 	}

--- a/test/omitempty/combos/marshaler/mymethod.go
+++ b/test/omitempty/combos/marshaler/mymethod.go
@@ -1,5 +1,5 @@
 package omitempty
 
-func (o *OmitEmpty_Inner) Empty() bool {
+func (o *OmitEmpty_Inner) IsEmpty() bool {
 	return o.Foo == 0
 }

--- a/test/omitempty/combos/marshaler/omitempty.pb.go
+++ b/test/omitempty/combos/marshaler/omitempty.pb.go
@@ -668,7 +668,7 @@ func (m *OmitEmpty) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	// Field has gogoproto.omitempty set.
-	if !m.InnerOmitEmpty.Empty() {
+	if !m.InnerOmitEmpty.IsEmpty() {
 		{
 			size, err := m.InnerOmitEmpty.MarshalToSizedBuffer(dAtA[:i])
 			if err != nil {
@@ -858,7 +858,7 @@ func (m *OmitEmpty) Size() (n int) {
 	l = m.InnerNotNullable.Size()
 	n += 1 + l + sovOmitempty(uint64(l))
 	// Field has gogoproto.omitempty set.
-	if !m.InnerOmitEmpty.Empty() {
+	if !m.InnerOmitEmpty.IsEmpty() {
 		l = m.InnerOmitEmpty.Size()
 		n += 1 + l + sovOmitempty(uint64(l))
 	}

--- a/test/omitempty/combos/neither/mymethod.go
+++ b/test/omitempty/combos/neither/mymethod.go
@@ -1,5 +1,5 @@
 package omitempty
 
-func (o *OmitEmpty_Inner) Empty() bool {
+func (o *OmitEmpty_Inner) IsEmpty() bool {
 	return o.Foo == 0
 }

--- a/test/omitempty/combos/neither/omitempty.pb.go
+++ b/test/omitempty/combos/neither/omitempty.pb.go
@@ -737,7 +737,7 @@ func (m *OmitEmpty) Size() (n int) {
 	l = m.InnerNotNullable.Size()
 	n += 1 + l + sovOmitempty(uint64(l))
 	// Field has gogoproto.omitempty set.
-	if !m.InnerOmitEmpty.Empty() {
+	if !m.InnerOmitEmpty.IsEmpty() {
 		l = m.InnerOmitEmpty.Size()
 		n += 1 + l + sovOmitempty(uint64(l))
 	}

--- a/test/omitempty/combos/unmarshaler/mymethod.go
+++ b/test/omitempty/combos/unmarshaler/mymethod.go
@@ -1,5 +1,5 @@
 package omitempty
 
-func (o *OmitEmpty_Inner) Empty() bool {
+func (o *OmitEmpty_Inner) IsEmpty() bool {
 	return o.Foo == 0
 }

--- a/test/omitempty/combos/unmarshaler/omitempty.pb.go
+++ b/test/omitempty/combos/unmarshaler/omitempty.pb.go
@@ -740,7 +740,7 @@ func (m *OmitEmpty) Size() (n int) {
 	l = m.InnerNotNullable.Size()
 	n += 1 + l + sovOmitempty(uint64(l))
 	// Field has gogoproto.omitempty set.
-	if !m.InnerOmitEmpty.Empty() {
+	if !m.InnerOmitEmpty.IsEmpty() {
 		l = m.InnerOmitEmpty.Size()
 		n += 1 + l + sovOmitempty(uint64(l))
 	}


### PR DESCRIPTION
The omitempty option will be used to clean up the
MVCCValueHeaderPure/MVCCValueHeaderCrdbTest hack.

This commit changes the generated code to rely on an `IsEmpty()` method (instead of `Empty`). Timestamp already has an `IsEmpty()` method which is used in many places; plus "is empty" is better ("empty" can be interpreted as an imperative verb).