### PR TITLE
oneof: batch allocate oneof wrapper and field messages

### DIFF
--- a/plugin/unmarshal/unmarshal.go
+++ b/plugin/unmarshal/unmarshal.go
@@ -695,6 +695,11 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`v := time.Time{}`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdTimeUnmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else if gogoproto.IsStdDuration(field) {
 				if nullable {
 					p.P(`v := new(time.Duration)`)
@@ -703,6 +708,11 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`v := time.Duration(0)`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdDurationUnmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else if gogoproto.IsStdDouble(field) {
 				if nullable {
 					p.P(`v := new(float64)`)
@@ -711,6 +721,11 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`v := 0`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdDoubleUnmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else if gogoproto.IsStdFloat(field) {
 				if nullable {
 					p.P(`v := new(float32)`)
@@ -719,6 +734,11 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`v := 0`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdFloatUnmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else if gogoproto.IsStdInt64(field) {
 				if nullable {
 					p.P(`v := new(int64)`)
@@ -727,6 +747,11 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`v := 0`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdInt64Unmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else if gogoproto.IsStdUInt64(field) {
 				if nullable {
 					p.P(`v := new(uint64)`)
@@ -735,6 +760,11 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`v := 0`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdUInt64Unmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else if gogoproto.IsStdInt32(field) {
 				if nullable {
 					p.P(`v := new(int32)`)
@@ -743,6 +773,11 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`v := 0`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdInt32Unmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else if gogoproto.IsStdUInt32(field) {
 				if nullable {
 					p.P(`v := new(uint32)`)
@@ -751,6 +786,11 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`v := 0`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdUInt32Unmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else if gogoproto.IsStdBool(field) {
 				if nullable {
 					p.P(`v := new(bool)`)
@@ -759,6 +799,11 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`v := false`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdBoolUnmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else if gogoproto.IsStdString(field) {
 				if nullable {
 					p.P(`v := new(string)`)
@@ -767,6 +812,11 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`v := ""`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdStringUnmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else if gogoproto.IsStdBytes(field) {
 				if nullable {
 					p.P(`v := new([]byte)`)
@@ -775,15 +825,26 @@ func (p *unmarshal) field(file *generator.FileDescriptor, msg *generator.Descrip
 					p.P(`var v []byte`)
 					p.P(`if err := `, p.typesPkg.Use(), `.StdBytesUnmarshal(&v, `, buf, `); err != nil {`)
 				}
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 			} else {
-				p.P(`v := &`, msgname, `{}`)
-				p.P(`if err := v.Unmarshal(`, buf, `); err != nil {`)
+				p.P(`alloc := new(struct {`)
+				p.In()
+				p.P(`value `, p.OneOfTypeName(msg, field))
+				p.P(`field `, msgname)
+				p.Out()
+				p.P(`})`)
+				p.P(`if err := alloc.field.Unmarshal(`, buf, `); err != nil {`)
+				p.In()
+				p.P(`return err`)
+				p.Out()
+				p.P(`}`)
+				p.P(`alloc.value.`, p.GetOneOfFieldName(msg, field), ` = &alloc.field`)
+				p.P(`m.`, fieldname, ` = &alloc.value`)
 			}
-			p.In()
-			p.P(`return err`)
-			p.Out()
-			p.P(`}`)
-			p.P(`m.`, fieldname, ` = &`, p.OneOfTypeName(msg, field), `{v}`)
 		} else if p.IsMap(field) {
 			m := p.GoMapType(nil, field)
 

--- a/test/issue617/issue617.pb.go
+++ b/test/issue617/issue617.pb.go
@@ -357,11 +357,15 @@ func (m *Foo) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &Foo_Bar{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value Foo_Bar_
+				field Foo_Bar
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.Details = &Foo_Bar_{v}
+			alloc.value.Bar = &alloc.field
+			m.Details = &alloc.value
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/test/oneof/combos/both/one.pb.go
+++ b/test/oneof/combos/both/one.pb.go
@@ -6083,11 +6083,15 @@ func (m *AllTypesOneOf) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &Subby{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value AllTypesOneOf_SubMessage
+				field Subby
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.TestOneof = &AllTypesOneOf_SubMessage{v}
+			alloc.value.SubMessage = &alloc.field
+			m.TestOneof = &alloc.value
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -6276,11 +6280,15 @@ func (m *TwoOneofs) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &Subby{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value TwoOneofs_SubMessage2
+				field Subby
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.Two = &TwoOneofs_SubMessage2{v}
+			alloc.value.SubMessage2 = &alloc.field
+			m.Two = &alloc.value
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/test/oneof/combos/unmarshaler/one.pb.go
+++ b/test/oneof/combos/unmarshaler/one.pb.go
@@ -5501,11 +5501,15 @@ func (m *AllTypesOneOf) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &Subby{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value AllTypesOneOf_SubMessage
+				field Subby
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.TestOneof = &AllTypesOneOf_SubMessage{v}
+			alloc.value.SubMessage = &alloc.field
+			m.TestOneof = &alloc.value
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -5694,11 +5698,15 @@ func (m *TwoOneofs) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &Subby{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value TwoOneofs_SubMessage2
+				field Subby
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.Two = &TwoOneofs_SubMessage2{v}
+			alloc.value.SubMessage2 = &alloc.field
+			m.Two = &alloc.value
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/test/oneof3/combos/both/one.pb.go
+++ b/test/oneof3/combos/both/one.pb.go
@@ -3831,11 +3831,15 @@ func (m *SampleOneOf) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &Subby{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value SampleOneOf_SubMessage
+				field Subby
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.TestOneof = &SampleOneOf_SubMessage{v}
+			alloc.value.SubMessage = &alloc.field
+			m.TestOneof = &alloc.value
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/test/oneof3/combos/unmarshaler/one.pb.go
+++ b/test/oneof3/combos/unmarshaler/one.pb.go
@@ -3511,11 +3511,15 @@ func (m *SampleOneOf) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &Subby{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value SampleOneOf_SubMessage
+				field Subby
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.TestOneof = &SampleOneOf_SubMessage{v}
+			alloc.value.SubMessage = &alloc.field
+			m.TestOneof = &alloc.value
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/test/types/combos/both/types.pb.go
+++ b/test/types/combos/both/types.pb.go
@@ -20551,11 +20551,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.Timestamp{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_Timestamp
+				field types.Timestamp
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_Timestamp{v}
+			alloc.value.Timestamp = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
@@ -20586,11 +20590,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.Duration{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_Duration
+				field types.Duration
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_Duration{v}
+			alloc.value.Duration = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
@@ -20621,11 +20629,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.DoubleValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepDouble
+				field types.DoubleValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepDouble{v}
+			alloc.value.RepDouble = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
@@ -20656,11 +20668,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.FloatValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepFloat
+				field types.FloatValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepFloat{v}
+			alloc.value.RepFloat = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 5:
 			if wireType != 2 {
@@ -20691,11 +20707,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.Int64Value{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepInt64
+				field types.Int64Value
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepInt64{v}
+			alloc.value.RepInt64 = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 6:
 			if wireType != 2 {
@@ -20726,11 +20746,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.UInt64Value{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepUInt64
+				field types.UInt64Value
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepUInt64{v}
+			alloc.value.RepUInt64 = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 7:
 			if wireType != 2 {
@@ -20761,11 +20785,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.Int32Value{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepInt32
+				field types.Int32Value
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepInt32{v}
+			alloc.value.RepInt32 = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 8:
 			if wireType != 2 {
@@ -20796,11 +20824,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.UInt32Value{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepUInt32
+				field types.UInt32Value
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepUInt32{v}
+			alloc.value.RepUInt32 = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 9:
 			if wireType != 2 {
@@ -20831,11 +20863,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.BoolValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepBool
+				field types.BoolValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepBool{v}
+			alloc.value.RepBool = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 10:
 			if wireType != 2 {
@@ -20866,11 +20902,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.StringValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepString
+				field types.StringValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepString{v}
+			alloc.value.RepString = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 11:
 			if wireType != 2 {
@@ -20901,11 +20941,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.BytesValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepBytes
+				field types.BytesValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepBytes{v}
+			alloc.value.RepBytes = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/test/types/combos/unmarshaler/types.pb.go
+++ b/test/types/combos/unmarshaler/types.pb.go
@@ -17548,11 +17548,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.Timestamp{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_Timestamp
+				field types.Timestamp
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_Timestamp{v}
+			alloc.value.Timestamp = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
@@ -17583,11 +17587,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.Duration{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_Duration
+				field types.Duration
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_Duration{v}
+			alloc.value.Duration = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 3:
 			if wireType != 2 {
@@ -17618,11 +17626,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.DoubleValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepDouble
+				field types.DoubleValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepDouble{v}
+			alloc.value.RepDouble = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
@@ -17653,11 +17665,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.FloatValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepFloat
+				field types.FloatValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepFloat{v}
+			alloc.value.RepFloat = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 5:
 			if wireType != 2 {
@@ -17688,11 +17704,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.Int64Value{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepInt64
+				field types.Int64Value
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepInt64{v}
+			alloc.value.RepInt64 = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 6:
 			if wireType != 2 {
@@ -17723,11 +17743,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.UInt64Value{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepUInt64
+				field types.UInt64Value
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepUInt64{v}
+			alloc.value.RepUInt64 = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 7:
 			if wireType != 2 {
@@ -17758,11 +17782,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.Int32Value{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepInt32
+				field types.Int32Value
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepInt32{v}
+			alloc.value.RepInt32 = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 8:
 			if wireType != 2 {
@@ -17793,11 +17821,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.UInt32Value{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepUInt32
+				field types.UInt32Value
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepUInt32{v}
+			alloc.value.RepUInt32 = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 9:
 			if wireType != 2 {
@@ -17828,11 +17860,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.BoolValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepBool
+				field types.BoolValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepBool{v}
+			alloc.value.RepBool = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 10:
 			if wireType != 2 {
@@ -17863,11 +17899,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.StringValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepString
+				field types.StringValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepString{v}
+			alloc.value.RepString = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		case 11:
 			if wireType != 2 {
@@ -17898,11 +17938,15 @@ func (m *OneofProtoTypes) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &types.BytesValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value OneofProtoTypes_RepBytes
+				field types.BytesValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.OneOfProtoTimes = &OneofProtoTypes_RepBytes{v}
+			alloc.value.RepBytes = &alloc.field
+			m.OneOfProtoTimes = &alloc.value
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/types/struct.pb.go
+++ b/types/struct.pb.go
@@ -2037,11 +2037,15 @@ func (m *Value) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &Struct{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value Value_StructValue
+				field Struct
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.Kind = &Value_StructValue{v}
+			alloc.value.StructValue = &alloc.field
+			m.Kind = &alloc.value
 			iNdEx = postIndex
 		case 6:
 			if wireType != 2 {
@@ -2072,11 +2076,15 @@ func (m *Value) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			v := &ListValue{}
-			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			alloc := new(struct {
+				value Value_ListValue
+				field ListValue
+			})
+			if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
-			m.Kind = &Value_ListValue{v}
+			alloc.value.ListValue = &alloc.field
+			m.Kind = &alloc.value
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
This commit updates the unmarshalling logic for oneof messages to avoid a pair of heap allocations. Instead, we allocate a single object that contains both the oneof wrapper and the field message. We then point the wrapper to the field in the same heap object.

We were already playing this trick in CockroachDB. We'll benefit even more from it by adding it to gogoproto generated code.

For example, this changes generated code that looks like:
```go
v := &Struct{}
if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
	return err
}
m.Kind = &Value_StructValue{v}
```

into generated code that looks like:
```go
alloc := new(struct {
        value Value_StructValue
        field Struct
})
if err := alloc.field.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
        return err
}
alloc.value.StructValue = &alloc.field
m.Kind = &alloc.value
```