### PR TITLE
duration: don't serialize zero-valued std duration

### DIFF
--- a/gogoproto/helper.go
+++ b/gogoproto/helper.go
@@ -96,6 +96,10 @@ func IsStdType(field *google_protobuf.FieldDescriptorProto) bool {
 		IsStdString(field) || IsStdBytes(field))
 }
 
+func IsStdTypeAndNeedsZeroCheck(proto3 bool, field *google_protobuf.FieldDescriptorProto) bool {
+	return proto3 && !IsNullable(field) && IsStdDuration(field)
+}
+
 func IsWktPtr(field *google_protobuf.FieldDescriptorProto) bool {
 	return proto.GetBoolExtension(field.Options, E_Wktpointer, false)
 }

--- a/plugin/marshalto/marshalto.go
+++ b/plugin/marshalto/marshalto.go
@@ -764,6 +764,14 @@ func (p *marshalto) generateField(proto3 bool, numGen NumGen, file *generator.Fi
 			p.encodeKey(fieldNumber, wireType)
 			p.Out()
 			p.P(`}`)
+		} else if gogoproto.IsStdTypeAndNeedsZeroCheck(proto3, field) {
+			sizeOfVarName := `m.` + fieldname
+			p.P(`if `, sizeOfVarName, ` != 0 {`)
+			p.In()
+			p.marshalAllSizeOf(field, sizeOfVarName, numGen.Next())
+			p.encodeKey(fieldNumber, wireType)
+			p.Out()
+			p.P(`}`)
 		} else {
 			sizeOfVarName := `m.` + fieldname
 			if gogoproto.IsNullable(field) {

--- a/plugin/size/size.go
+++ b/plugin/size/size.go
@@ -504,6 +504,14 @@ func (p *size) generateField(proto3 bool, file *generator.FileDescriptor, messag
 			p.P(`n+=`, strconv.Itoa(key), `+l+sov`, p.localName, `(uint64(l))`)
 			p.Out()
 			p.P(`}`)
+		} else if gogoproto.IsStdTypeAndNeedsZeroCheck(proto3, field) {
+			p.P(`if m.`, fieldname, ` != 0 {`)
+			p.In()
+			stdSizeCall, _ := p.std(field, "m."+fieldname)
+			p.P(`l=`, stdSizeCall)
+			p.P(`n+=`, strconv.Itoa(key), `+l+sov`, p.localName, `(uint64(l))`)
+			p.Out()
+			p.P(`}`)
 		} else {
 			stdSizeCall, stdOk := p.std(field, "m."+fieldname)
 			if stdOk {

--- a/test/stdtypes/stdtypes.pb.go
+++ b/test/stdtypes/stdtypes.pb.go
@@ -3523,8 +3523,10 @@ func (m *StdTypes) Size() (n int) {
 	}
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.Timestamp)
 	n += 1 + l + sovStdtypes(uint64(l))
-	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration)
-	n += 1 + l + sovStdtypes(uint64(l))
+	if m.Duration != 0 {
+		l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration)
+		n += 1 + l + sovStdtypes(uint64(l))
+	}
 	if m.NullableDouble != nil {
 		l = github_com_gogo_protobuf_types.SizeOfStdDouble(*m.NullableDouble)
 		n += 1 + l + sovStdtypes(uint64(l))

--- a/test/types/combos/both/types.pb.go
+++ b/test/types/combos/both/types.pb.go
@@ -6894,14 +6894,16 @@ func (m *StdTypes) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i = encodeVarintTypes(dAtA, i, uint64(n43))
 	i--
 	dAtA[i] = 0x72
-	n44, err44 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Duration, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration):])
-	if err44 != nil {
-		return 0, err44
+	if m.Duration != 0 {
+		n44, err44 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Duration, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration):])
+		if err44 != nil {
+			return 0, err44
+		}
+		i -= n44
+		i = encodeVarintTypes(dAtA, i, uint64(n44))
+		i--
+		dAtA[i] = 0x6a
 	}
-	i -= n44
-	i = encodeVarintTypes(dAtA, i, uint64(n44))
-	i--
-	dAtA[i] = 0x6a
 	n45, err45 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Timestamp, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(m.Timestamp):])
 	if err45 != nil {
 		return 0, err45
@@ -10529,8 +10531,10 @@ func (m *StdTypes) Size() (n int) {
 	}
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.Timestamp)
 	n += 1 + l + sovTypes(uint64(l))
-	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration)
-	n += 1 + l + sovTypes(uint64(l))
+	if m.Duration != 0 {
+		l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration)
+		n += 1 + l + sovTypes(uint64(l))
+	}
 	l = github_com_gogo_protobuf_types.SizeOfStdDouble(m.NonnullDouble)
 	n += 1 + l + sovTypes(uint64(l))
 	l = github_com_gogo_protobuf_types.SizeOfStdFloat(m.NonnullFloat)

--- a/test/types/combos/marshaler/types.pb.go
+++ b/test/types/combos/marshaler/types.pb.go
@@ -6893,14 +6893,16 @@ func (m *StdTypes) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i = encodeVarintTypes(dAtA, i, uint64(n43))
 	i--
 	dAtA[i] = 0x72
-	n44, err44 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Duration, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration):])
-	if err44 != nil {
-		return 0, err44
+	if m.Duration != 0 {
+		n44, err44 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Duration, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration):])
+		if err44 != nil {
+			return 0, err44
+		}
+		i -= n44
+		i = encodeVarintTypes(dAtA, i, uint64(n44))
+		i--
+		dAtA[i] = 0x6a
 	}
-	i -= n44
-	i = encodeVarintTypes(dAtA, i, uint64(n44))
-	i--
-	dAtA[i] = 0x6a
 	n45, err45 := github_com_gogo_protobuf_types.StdTimeMarshalTo(m.Timestamp, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdTime(m.Timestamp):])
 	if err45 != nil {
 		return 0, err45
@@ -10528,8 +10530,10 @@ func (m *StdTypes) Size() (n int) {
 	}
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.Timestamp)
 	n += 1 + l + sovTypes(uint64(l))
-	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration)
-	n += 1 + l + sovTypes(uint64(l))
+	if m.Duration != 0 {
+		l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration)
+		n += 1 + l + sovTypes(uint64(l))
+	}
 	l = github_com_gogo_protobuf_types.SizeOfStdDouble(m.NonnullDouble)
 	n += 1 + l + sovTypes(uint64(l))
 	l = github_com_gogo_protobuf_types.SizeOfStdFloat(m.NonnullFloat)

--- a/test/types/combos/neither/types.pb.go
+++ b/test/types/combos/neither/types.pb.go
@@ -7525,8 +7525,10 @@ func (m *StdTypes) Size() (n int) {
 	}
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.Timestamp)
 	n += 1 + l + sovTypes(uint64(l))
-	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration)
-	n += 1 + l + sovTypes(uint64(l))
+	if m.Duration != 0 {
+		l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration)
+		n += 1 + l + sovTypes(uint64(l))
+	}
 	l = github_com_gogo_protobuf_types.SizeOfStdDouble(m.NonnullDouble)
 	n += 1 + l + sovTypes(uint64(l))
 	l = github_com_gogo_protobuf_types.SizeOfStdFloat(m.NonnullFloat)

--- a/test/types/combos/unmarshaler/types.pb.go
+++ b/test/types/combos/unmarshaler/types.pb.go
@@ -7526,8 +7526,10 @@ func (m *StdTypes) Size() (n int) {
 	}
 	l = github_com_gogo_protobuf_types.SizeOfStdTime(m.Timestamp)
 	n += 1 + l + sovTypes(uint64(l))
-	l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration)
-	n += 1 + l + sovTypes(uint64(l))
+	if m.Duration != 0 {
+		l = github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration)
+		n += 1 + l + sovTypes(uint64(l))
+	}
 	l = github_com_gogo_protobuf_types.SizeOfStdDouble(m.NonnullDouble)
 	n += 1 + l + sovTypes(uint64(l))
 	l = github_com_gogo_protobuf_types.SizeOfStdFloat(m.NonnullFloat)

--- a/types/duration.go
+++ b/types/duration.go
@@ -56,14 +56,14 @@ func validateDuration(d *Duration) error {
 		return errors.New("duration: nil Duration")
 	}
 	if d.Seconds < minSeconds || d.Seconds > maxSeconds {
-		return fmt.Errorf("duration: %#v: seconds out of range", d)
+		return fmt.Errorf("duration: %s: seconds out of range", d.GoString())
 	}
 	if d.Nanos <= -1e9 || d.Nanos >= 1e9 {
-		return fmt.Errorf("duration: %#v: nanos out of range", d)
+		return fmt.Errorf("duration: %s: nanos out of range", d.GoString())
 	}
 	// Seconds and Nanos must have the same sign, unless d.Nanos is zero.
 	if (d.Seconds < 0 && d.Nanos > 0) || (d.Seconds > 0 && d.Nanos < 0) {
-		return fmt.Errorf("duration: %#v: seconds and nanos have different signs", d)
+		return fmt.Errorf("duration: %s: seconds and nanos have different signs", d.GoString())
 	}
 	return nil
 }
@@ -77,12 +77,12 @@ func DurationFromProto(p *Duration) (time.Duration, error) {
 	}
 	d := time.Duration(p.Seconds) * time.Second
 	if int64(d/time.Second) != p.Seconds {
-		return 0, fmt.Errorf("duration: %#v is out of range for time.Duration", p)
+		return 0, fmt.Errorf("duration: %s is out of range for time.Duration", p.GoString())
 	}
 	if p.Nanos != 0 {
 		d += time.Duration(p.Nanos) * time.Nanosecond
 		if (d < 0) != (p.Nanos < 0) {
-			return 0, fmt.Errorf("duration: %#v is out of range for time.Duration", p)
+			return 0, fmt.Errorf("duration: %s is out of range for time.Duration", p.GoString())
 		}
 	}
 	return d, nil


### PR DESCRIPTION
This commit updates the serialization of `time.Duration` (see `gogo.stdduration`) to avoid serializing the default (zero) value in proto3. In Go, `time.Duration` is a typedef of int64, so it was surprising that unlike int64, the zero value of time.Duration fields were being put on the wire.

While here, we also fix `DurationFromProto` to not cause its input to escape to the heap by passing it through `fmt.Errorf`. This function is called from `StdDurationUnmarshal` and its unintentional heap allocation what alerted me to the zero-value serialization issue.